### PR TITLE
feat: add Solana long-basket assets to mainnet pirin-1

### DIFF
--- a/mainnet/pirin-1/currencies.json
+++ b/mainnet/pirin-1/currencies.json
@@ -920,69 +920,6 @@
             },
             "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-sol.svg"
           },
-          "JUP": {
-            "native": {
-              "name": "Jupiter",
-              "symbol": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
-              "ticker": "JUP",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jup.svg"
-          },
-          "JLP": {
-            "native": {
-              "name": "Jupiter LP",
-              "symbol": "27G8MtK7VtTcCHkpASjSDdkWWYfoqT6ggEuKidVJidD4",
-              "ticker": "JLP",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jlp.svg"
-          },
-          "MET": {
-            "native": {
-              "name": "Meteora",
-              "symbol": "METvsvVRapdj9cFLzq4Tr43xK4tAjQfwX76z3n6mWQL",
-              "ticker": "MET",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-met.svg"
-          },
-          "PENGU": {
-            "native": {
-              "name": "Pudgy Penguins",
-              "symbol": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
-              "ticker": "PENGU",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-pengu.svg"
-          },
-          "TRUMP": {
-            "native": {
-              "name": "Official Trump",
-              "symbol": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
-              "ticker": "TRUMP",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-trump.svg"
-          },
-          "PUMP": {
-            "native": {
-              "name": "Pump.fun",
-              "symbol": "pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn",
-              "ticker": "PUMP",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-pump.svg"
-          },
-          "JTO": {
-            "native": {
-              "name": "Jito",
-              "symbol": "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
-              "ticker": "JTO",
-              "decimal_digits": "9"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jto.svg"
-          },
           "CB_BTC": {
             "native": {
               "name": "Coinbase Wrapped BTC",
@@ -991,15 +928,6 @@
               "decimal_digits": "8"
             },
             "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-cbbtc.svg"
-          },
-          "JITO_SOL": {
-            "native": {
-              "name": "Jito Staked SOL",
-              "symbol": "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
-              "ticker": "JITO_SOL",
-              "decimal_digits": "9"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jitosol.svg"
           },
           "W_ETH": {
             "native": {
@@ -1010,15 +938,6 @@
             },
             "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-weth.svg"
           },
-          "XAUT0": {
-            "native": {
-              "name": "Tether Gold",
-              "symbol": "AymATz4TCL9sWNEEV9Kvyz45CHVhDZ6kUgjTJPzLpU9P",
-              "ticker": "XAUT0",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-xaut0.svg"
-          },
           "HYPE": {
             "native": {
               "name": "Hyperliquid",
@@ -1027,150 +946,6 @@
               "decimal_digits": "9"
             },
             "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-hype.svg"
-          },
-          "ZEC": {
-            "native": {
-              "name": "Zcash",
-              "symbol": "A7bdiYdS5GjqGFtxf17ppRHtDKPkkRqbKtR27dxvQXaS",
-              "ticker": "ZEC",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-zec.svg"
-          },
-          "RAY": {
-            "native": {
-              "name": "Raydium",
-              "symbol": "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
-              "ticker": "RAY",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-ray.svg"
-          },
-          "ORCA": {
-            "native": {
-              "name": "Orca",
-              "symbol": "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE",
-              "ticker": "ORCA",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-orca.svg"
-          },
-          "BP": {
-            "native": {
-              "name": "Backpack",
-              "symbol": "BPxxfRCXkUVhig4HS1Lh7kZqV6SPJhzfEk4x6fVBjPCy",
-              "ticker": "BP",
-              "decimal_digits": "9"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-bp.svg"
-          },
-          "MU": {
-            "native": {
-              "name": "Micron",
-              "symbol": "MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1",
-              "ticker": "MU",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-mu.svg"
-          },
-          "SPCX": {
-            "native": {
-              "name": "SpaceX (Tokenized Stock)",
-              "symbol": "SPCXxcqXj6e5dJDVNovHN8744zkbhM2bYudU45BimGb",
-              "ticker": "SPCX",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-spcx.svg"
-          },
-          "SKHY": {
-            "native": {
-              "name": "SKHY",
-              "symbol": "SKHYhSjuRWHgikq8eRKbtBbpABgJSkd7ytQV14i9EQ3",
-              "ticker": "SKHY",
-              "decimal_digits": "6"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-skhy.svg"
-          },
-          "SPYX": {
-            "native": {
-              "name": "SPDR S&P 500 ETF Trust (xStock)",
-              "symbol": "XsoCS1TfEyfFhfvj8EtZ528L3CaKBDBRqRapnBbDF2W",
-              "ticker": "SPYX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-spyx.svg"
-          },
-          "QQQX": {
-            "native": {
-              "name": "Invesco QQQ Trust (xStock)",
-              "symbol": "Xs8S1uUs1zvS2p7iwtsG3b6fkhpvmwz4GYU3gWAmWHZ",
-              "ticker": "QQQX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-qqqx.svg"
-          },
-          "NVDAX": {
-            "native": {
-              "name": "NVIDIA (xStock)",
-              "symbol": "Xsc9qvGR1efVDFGLrVsmkzv3qi45LTBjeUKSPmx9qEh",
-              "ticker": "NVDAX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-nvdax.svg"
-          },
-          "CRCLX": {
-            "native": {
-              "name": "Circle (xStock)",
-              "symbol": "XsueG8BtpquVJX9LVLLEGuViXUungE6WmK5YZ3p3bd1",
-              "ticker": "CRCLX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-crclx.svg"
-          },
-          "TSLAX": {
-            "native": {
-              "name": "Tesla (xStock)",
-              "symbol": "XsDoVfqeBukxuZHWhdvWHBhgEHjGNst4MLodqsJHzoB",
-              "ticker": "TSLAX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-tslax.svg"
-          },
-          "COINX": {
-            "native": {
-              "name": "Coinbase (xStock)",
-              "symbol": "Xs7ZdzSHLU9ftNJsii5fCeJhoRWSC32SQGzGQtePxNu",
-              "ticker": "COINX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-coinx.svg"
-          },
-          "MSTRX": {
-            "native": {
-              "name": "Strategy (xStock)",
-              "symbol": "XsP7xzNPvEHS1m6qfanPUGjNmdnmsLKEoNAnHjdxxyZ",
-              "ticker": "MSTRX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-mstrx.svg"
-          },
-          "GOOGLX": {
-            "native": {
-              "name": "Alphabet (xStock)",
-              "symbol": "XsCPL9dNWBMvFtTmwcCA5v3xWPSMEBCszbQdiLLq6aN",
-              "ticker": "GOOGLX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-googlx.svg"
-          },
-          "AAPLX": {
-            "native": {
-              "name": "Apple (xStock)",
-              "symbol": "XsbEhLAtcf6HdfpFZ5xEMdqW8nfAvcsP5bdudRLJzJp",
-              "ticker": "AAPLX",
-              "decimal_digits": "8"
-            },
-            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-aaplx.svg"
           },
           "USDC": {
             "native": {
@@ -2739,89 +2514,14 @@
         "SOL": {
           "dex_currency": "SOL"
         },
-        "JUP": {
-          "dex_currency": "JUP"
-        },
-        "JLP": {
-          "dex_currency": "JLP"
-        },
-        "MET": {
-          "dex_currency": "MET"
-        },
-        "PENGU": {
-          "dex_currency": "PENGU"
-        },
-        "TRUMP": {
-          "dex_currency": "TRUMP"
-        },
-        "PUMP": {
-          "dex_currency": "PUMP"
-        },
-        "JTO": {
-          "dex_currency": "JTO"
-        },
         "CB_BTC": {
           "dex_currency": "CB_BTC"
-        },
-        "JITO_SOL": {
-          "dex_currency": "JITO_SOL"
         },
         "W_ETH": {
           "dex_currency": "W_ETH"
         },
-        "XAUT0": {
-          "dex_currency": "XAUT0"
-        },
         "HYPE": {
           "dex_currency": "HYPE"
-        },
-        "ZEC": {
-          "dex_currency": "ZEC"
-        },
-        "RAY": {
-          "dex_currency": "RAY"
-        },
-        "ORCA": {
-          "dex_currency": "ORCA"
-        },
-        "BP": {
-          "dex_currency": "BP"
-        },
-        "MU": {
-          "dex_currency": "MU"
-        },
-        "SPCX": {
-          "dex_currency": "SPCX"
-        },
-        "SKHY": {
-          "dex_currency": "SKHY"
-        },
-        "SPYX": {
-          "dex_currency": "SPYX"
-        },
-        "QQQX": {
-          "dex_currency": "QQQX"
-        },
-        "NVDAX": {
-          "dex_currency": "NVDAX"
-        },
-        "CRCLX": {
-          "dex_currency": "CRCLX"
-        },
-        "TSLAX": {
-          "dex_currency": "TSLAX"
-        },
-        "COINX": {
-          "dex_currency": "COINX"
-        },
-        "MSTRX": {
-          "dex_currency": "MSTRX"
-        },
-        "GOOGLX": {
-          "dex_currency": "GOOGLX"
-        },
-        "AAPLX": {
-          "dex_currency": "AAPLX"
         }
       },
       "Native": {

--- a/mainnet/pirin-1/currencies.json
+++ b/mainnet/pirin-1/currencies.json
@@ -929,11 +929,11 @@
             },
             "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-cbbtc.svg"
           },
-          "W_ETH": {
+          "WETH": {
             "native": {
               "name": "Wrapped Ether",
               "symbol": "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
-              "ticker": "W_ETH",
+              "ticker": "WETH",
               "decimal_digits": "8"
             },
             "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-weth.svg"
@@ -2517,8 +2517,8 @@
         "CB_BTC": {
           "dex_currency": "CB_BTC"
         },
-        "W_ETH": {
-          "dex_currency": "W_ETH"
+        "WETH": {
+          "dex_currency": "WETH"
         },
         "HYPE": {
           "dex_currency": "HYPE"

--- a/mainnet/pirin-1/currencies.json
+++ b/mainnet/pirin-1/currencies.json
@@ -955,6 +955,13 @@
               "decimal_digits": "6"
             },
             "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-usdc.svg"
+          },
+          "NLS": {
+            "ibc": {
+              "network": "NOLUS",
+              "currency": "NLS"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-nls.svg"
           }
         },
         "amm_pools": []

--- a/mainnet/pirin-1/currencies.json
+++ b/mainnet/pirin-1/currencies.json
@@ -1284,11 +1284,11 @@
       {
         "a": {
           "network": "NOLUS",
-          "ch": "channel-XX"
+          "ch": "channel-61957"
         },
         "b": {
           "network": "SOLANA",
-          "ch": "channel-XX"
+          "ch": "channel-0"
         }
       }
     ]

--- a/mainnet/pirin-1/currencies.json
+++ b/mainnet/pirin-1/currencies.json
@@ -908,6 +908,281 @@
             }
           }
         }
+      },
+      "SOLANA": {
+        "currencies": {
+          "SOL": {
+            "native": {
+              "name": "Solana",
+              "symbol": "So11111111111111111111111111111111111111112",
+              "ticker": "SOL",
+              "decimal_digits": "9"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-sol.svg"
+          },
+          "JUP": {
+            "native": {
+              "name": "Jupiter",
+              "symbol": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
+              "ticker": "JUP",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jup.svg"
+          },
+          "JLP": {
+            "native": {
+              "name": "Jupiter LP",
+              "symbol": "27G8MtK7VtTcCHkpASjSDdkWWYfoqT6ggEuKidVJidD4",
+              "ticker": "JLP",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jlp.svg"
+          },
+          "MET": {
+            "native": {
+              "name": "Meteora",
+              "symbol": "METvsvVRapdj9cFLzq4Tr43xK4tAjQfwX76z3n6mWQL",
+              "ticker": "MET",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-met.svg"
+          },
+          "PENGU": {
+            "native": {
+              "name": "Pudgy Penguins",
+              "symbol": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
+              "ticker": "PENGU",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-pengu.svg"
+          },
+          "TRUMP": {
+            "native": {
+              "name": "Official Trump",
+              "symbol": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
+              "ticker": "TRUMP",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-trump.svg"
+          },
+          "PUMP": {
+            "native": {
+              "name": "Pump.fun",
+              "symbol": "pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn",
+              "ticker": "PUMP",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-pump.svg"
+          },
+          "JTO": {
+            "native": {
+              "name": "Jito",
+              "symbol": "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
+              "ticker": "JTO",
+              "decimal_digits": "9"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jto.svg"
+          },
+          "CB_BTC": {
+            "native": {
+              "name": "Coinbase Wrapped BTC",
+              "symbol": "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij",
+              "ticker": "CB_BTC",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-cbbtc.svg"
+          },
+          "JITO_SOL": {
+            "native": {
+              "name": "Jito Staked SOL",
+              "symbol": "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
+              "ticker": "JITO_SOL",
+              "decimal_digits": "9"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jitosol.svg"
+          },
+          "W_ETH": {
+            "native": {
+              "name": "Wrapped Ether",
+              "symbol": "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+              "ticker": "W_ETH",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-weth.svg"
+          },
+          "XAUT0": {
+            "native": {
+              "name": "Tether Gold",
+              "symbol": "AymATz4TCL9sWNEEV9Kvyz45CHVhDZ6kUgjTJPzLpU9P",
+              "ticker": "XAUT0",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-xaut0.svg"
+          },
+          "HYPE": {
+            "native": {
+              "name": "Hyperliquid",
+              "symbol": "98sMhvDwXj1RQi5c5Mndm3vPe9cBqPrbLaufMXFNMh5g",
+              "ticker": "HYPE",
+              "decimal_digits": "9"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-hype.svg"
+          },
+          "ZEC": {
+            "native": {
+              "name": "Zcash",
+              "symbol": "A7bdiYdS5GjqGFtxf17ppRHtDKPkkRqbKtR27dxvQXaS",
+              "ticker": "ZEC",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-zec.svg"
+          },
+          "RAY": {
+            "native": {
+              "name": "Raydium",
+              "symbol": "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
+              "ticker": "RAY",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-ray.svg"
+          },
+          "ORCA": {
+            "native": {
+              "name": "Orca",
+              "symbol": "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE",
+              "ticker": "ORCA",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-orca.svg"
+          },
+          "BP": {
+            "native": {
+              "name": "Backpack",
+              "symbol": "BPxxfRCXkUVhig4HS1Lh7kZqV6SPJhzfEk4x6fVBjPCy",
+              "ticker": "BP",
+              "decimal_digits": "9"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-bp.svg"
+          },
+          "MU": {
+            "native": {
+              "name": "Micron",
+              "symbol": "MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1",
+              "ticker": "MU",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-mu.svg"
+          },
+          "SPCX": {
+            "native": {
+              "name": "SpaceX (Tokenized Stock)",
+              "symbol": "SPCXxcqXj6e5dJDVNovHN8744zkbhM2bYudU45BimGb",
+              "ticker": "SPCX",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-spcx.svg"
+          },
+          "SKHY": {
+            "native": {
+              "name": "SKHY",
+              "symbol": "SKHYhSjuRWHgikq8eRKbtBbpABgJSkd7ytQV14i9EQ3",
+              "ticker": "SKHY",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-skhy.svg"
+          },
+          "SPYX": {
+            "native": {
+              "name": "SPDR S&P 500 ETF Trust (xStock)",
+              "symbol": "XsoCS1TfEyfFhfvj8EtZ528L3CaKBDBRqRapnBbDF2W",
+              "ticker": "SPYX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-spyx.svg"
+          },
+          "QQQX": {
+            "native": {
+              "name": "Invesco QQQ Trust (xStock)",
+              "symbol": "Xs8S1uUs1zvS2p7iwtsG3b6fkhpvmwz4GYU3gWAmWHZ",
+              "ticker": "QQQX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-qqqx.svg"
+          },
+          "NVDAX": {
+            "native": {
+              "name": "NVIDIA (xStock)",
+              "symbol": "Xsc9qvGR1efVDFGLrVsmkzv3qi45LTBjeUKSPmx9qEh",
+              "ticker": "NVDAX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-nvdax.svg"
+          },
+          "CRCLX": {
+            "native": {
+              "name": "Circle (xStock)",
+              "symbol": "XsueG8BtpquVJX9LVLLEGuViXUungE6WmK5YZ3p3bd1",
+              "ticker": "CRCLX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-crclx.svg"
+          },
+          "TSLAX": {
+            "native": {
+              "name": "Tesla (xStock)",
+              "symbol": "XsDoVfqeBukxuZHWhdvWHBhgEHjGNst4MLodqsJHzoB",
+              "ticker": "TSLAX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-tslax.svg"
+          },
+          "COINX": {
+            "native": {
+              "name": "Coinbase (xStock)",
+              "symbol": "Xs7ZdzSHLU9ftNJsii5fCeJhoRWSC32SQGzGQtePxNu",
+              "ticker": "COINX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-coinx.svg"
+          },
+          "MSTRX": {
+            "native": {
+              "name": "Strategy (xStock)",
+              "symbol": "XsP7xzNPvEHS1m6qfanPUGjNmdnmsLKEoNAnHjdxxyZ",
+              "ticker": "MSTRX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-mstrx.svg"
+          },
+          "GOOGLX": {
+            "native": {
+              "name": "Alphabet (xStock)",
+              "symbol": "XsCPL9dNWBMvFtTmwcCA5v3xWPSMEBCszbQdiLLq6aN",
+              "ticker": "GOOGLX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-googlx.svg"
+          },
+          "AAPLX": {
+            "native": {
+              "name": "Apple (xStock)",
+              "symbol": "XsbEhLAtcf6HdfpFZ5xEMdqW8nfAvcsP5bdudRLJzJp",
+              "ticker": "AAPLX",
+              "decimal_digits": "8"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-aaplx.svg"
+          },
+          "USDC": {
+            "native": {
+              "name": "Circle USDC",
+              "symbol": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              "ticker": "USDC",
+              "decimal_digits": "6"
+            },
+            "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-usdc.svg"
+          }
+        },
+        "amm_pools": []
       }
     },
     "channels": [
@@ -1229,6 +1504,16 @@
         "b": {
           "network": "NOBLE",
           "ch": "channel-18"
+        }
+      },
+      {
+        "a": {
+          "network": "NOLUS",
+          "ch": "channel-XX"
+        },
+        "b": {
+          "network": "SOLANA",
+          "ch": "channel-XX"
         }
       }
     ]
@@ -2443,6 +2728,104 @@
         "USDC_NOBLE": {
           "dex_currency": "USDC_NOBLE"
         }
+      }
+    },
+    "SOLANA-METIS-USDC": {
+      "DexNetwork": "SOLANA",
+      "Lpn": {
+        "dex_currency": "USDC"
+      },
+      "Lease": {
+        "SOL": {
+          "dex_currency": "SOL"
+        },
+        "JUP": {
+          "dex_currency": "JUP"
+        },
+        "JLP": {
+          "dex_currency": "JLP"
+        },
+        "MET": {
+          "dex_currency": "MET"
+        },
+        "PENGU": {
+          "dex_currency": "PENGU"
+        },
+        "TRUMP": {
+          "dex_currency": "TRUMP"
+        },
+        "PUMP": {
+          "dex_currency": "PUMP"
+        },
+        "JTO": {
+          "dex_currency": "JTO"
+        },
+        "CB_BTC": {
+          "dex_currency": "CB_BTC"
+        },
+        "JITO_SOL": {
+          "dex_currency": "JITO_SOL"
+        },
+        "W_ETH": {
+          "dex_currency": "W_ETH"
+        },
+        "XAUT0": {
+          "dex_currency": "XAUT0"
+        },
+        "HYPE": {
+          "dex_currency": "HYPE"
+        },
+        "ZEC": {
+          "dex_currency": "ZEC"
+        },
+        "RAY": {
+          "dex_currency": "RAY"
+        },
+        "ORCA": {
+          "dex_currency": "ORCA"
+        },
+        "BP": {
+          "dex_currency": "BP"
+        },
+        "MU": {
+          "dex_currency": "MU"
+        },
+        "SPCX": {
+          "dex_currency": "SPCX"
+        },
+        "SKHY": {
+          "dex_currency": "SKHY"
+        },
+        "SPYX": {
+          "dex_currency": "SPYX"
+        },
+        "QQQX": {
+          "dex_currency": "QQQX"
+        },
+        "NVDAX": {
+          "dex_currency": "NVDAX"
+        },
+        "CRCLX": {
+          "dex_currency": "CRCLX"
+        },
+        "TSLAX": {
+          "dex_currency": "TSLAX"
+        },
+        "COINX": {
+          "dex_currency": "COINX"
+        },
+        "MSTRX": {
+          "dex_currency": "MSTRX"
+        },
+        "GOOGLX": {
+          "dex_currency": "GOOGLX"
+        },
+        "AAPLX": {
+          "dex_currency": "AAPLX"
+        }
+      },
+      "Native": {
+        "dex_currency": "NLS"
       }
     }
   },

--- a/mainnet/pirin-1/topology.json
+++ b/mainnet/pirin-1/topology.json
@@ -553,6 +553,257 @@
                 }
             }
         },
+        "SOLANA": {
+            "currencies": {
+                "SOL": {
+                    "native": {
+                        "name": "SOL",
+                        "symbol": "So11111111111111111111111111111111111111112",
+                        "decimal_digits": 9
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-sol.svg"
+                },
+                "JUP": {
+                    "native": {
+                        "name": "JUP",
+                        "symbol": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jup.svg"
+                },
+                "JLP": {
+                    "native": {
+                        "name": "JLP",
+                        "symbol": "27G8MtK7VtTcCHkpASjSDdkWWYfoqT6ggEuKidVJidD4",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jlp.svg"
+                },
+                "MET": {
+                    "native": {
+                        "name": "MET",
+                        "symbol": "METvsvVRapdj9cFLzq4Tr43xK4tAjQfwX76z3n6mWQL",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-met.svg"
+                },
+                "PENGU": {
+                    "native": {
+                        "name": "PENGU",
+                        "symbol": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-pengu.svg"
+                },
+                "TRUMP": {
+                    "native": {
+                        "name": "TRUMP",
+                        "symbol": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-trump.svg"
+                },
+                "PUMP": {
+                    "native": {
+                        "name": "PUMP",
+                        "symbol": "pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-pump.svg"
+                },
+                "JTO": {
+                    "native": {
+                        "name": "JTO",
+                        "symbol": "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
+                        "decimal_digits": 9
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jto.svg"
+                },
+                "CB_BTC": {
+                    "native": {
+                        "name": "CB_BTC",
+                        "symbol": "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-cbbtc.svg"
+                },
+                "JITO_SOL": {
+                    "native": {
+                        "name": "JITO_SOL",
+                        "symbol": "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
+                        "decimal_digits": 9
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jitosol.svg"
+                },
+                "W_ETH": {
+                    "native": {
+                        "name": "W_ETH",
+                        "symbol": "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-weth.svg"
+                },
+                "XAUT0": {
+                    "native": {
+                        "name": "XAUT0",
+                        "symbol": "AymATz4TCL9sWNEEV9Kvyz45CHVhDZ6kUgjTJPzLpU9P",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-xaut0.svg"
+                },
+                "HYPE": {
+                    "native": {
+                        "name": "HYPE",
+                        "symbol": "98sMhvDwXj1RQi5c5Mndm3vPe9cBqPrbLaufMXFNMh5g",
+                        "decimal_digits": 9
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-hype.svg"
+                },
+                "ZEC": {
+                    "native": {
+                        "name": "ZEC",
+                        "symbol": "A7bdiYdS5GjqGFtxf17ppRHtDKPkkRqbKtR27dxvQXaS",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-zec.svg"
+                },
+                "RAY": {
+                    "native": {
+                        "name": "RAY",
+                        "symbol": "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-ray.svg"
+                },
+                "ORCA": {
+                    "native": {
+                        "name": "ORCA",
+                        "symbol": "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-orca.svg"
+                },
+                "BP": {
+                    "native": {
+                        "name": "BP",
+                        "symbol": "BPxxfRCXkUVhig4HS1Lh7kZqV6SPJhzfEk4x6fVBjPCy",
+                        "decimal_digits": 9
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-bp.svg"
+                },
+                "MU": {
+                    "native": {
+                        "name": "MU",
+                        "symbol": "MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-mu.svg"
+                },
+                "SPCX": {
+                    "native": {
+                        "name": "SPCX",
+                        "symbol": "SPCXxcqXj6e5dJDVNovHN8744zkbhM2bYudU45BimGb",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-spcx.svg"
+                },
+                "SKHY": {
+                    "native": {
+                        "name": "SKHY",
+                        "symbol": "SKHYhSjuRWHgikq8eRKbtBbpABgJSkd7ytQV14i9EQ3",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-skhy.svg"
+                },
+                "SPYX": {
+                    "native": {
+                        "name": "SPYX",
+                        "symbol": "XsoCS1TfEyfFhfvj8EtZ528L3CaKBDBRqRapnBbDF2W",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-spyx.svg"
+                },
+                "QQQX": {
+                    "native": {
+                        "name": "QQQX",
+                        "symbol": "Xs8S1uUs1zvS2p7iwtsG3b6fkhpvmwz4GYU3gWAmWHZ",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-qqqx.svg"
+                },
+                "NVDAX": {
+                    "native": {
+                        "name": "NVDAX",
+                        "symbol": "Xsc9qvGR1efVDFGLrVsmkzv3qi45LTBjeUKSPmx9qEh",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-nvdax.svg"
+                },
+                "CRCLX": {
+                    "native": {
+                        "name": "CRCLX",
+                        "symbol": "XsueG8BtpquVJX9LVLLEGuViXUungE6WmK5YZ3p3bd1",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-crclx.svg"
+                },
+                "TSLAX": {
+                    "native": {
+                        "name": "TSLAX",
+                        "symbol": "XsDoVfqeBukxuZHWhdvWHBhgEHjGNst4MLodqsJHzoB",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-tslax.svg"
+                },
+                "COINX": {
+                    "native": {
+                        "name": "COINX",
+                        "symbol": "Xs7ZdzSHLU9ftNJsii5fCeJhoRWSC32SQGzGQtePxNu",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-coinx.svg"
+                },
+                "MSTRX": {
+                    "native": {
+                        "name": "MSTRX",
+                        "symbol": "XsP7xzNPvEHS1m6qfanPUGjNmdnmsLKEoNAnHjdxxyZ",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-mstrx.svg"
+                },
+                "GOOGLX": {
+                    "native": {
+                        "name": "GOOGLX",
+                        "symbol": "XsCPL9dNWBMvFtTmwcCA5v3xWPSMEBCszbQdiLLq6aN",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-googlx.svg"
+                },
+                "AAPLX": {
+                    "native": {
+                        "name": "AAPLX",
+                        "symbol": "XsbEhLAtcf6HdfpFZ5xEMdqW8nfAvcsP5bdudRLJzJp",
+                        "decimal_digits": 8
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-aaplx.svg"
+                },
+                "USDC": {
+                    "native": {
+                        "name": "USDC",
+                        "symbol": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                        "decimal_digits": 6
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-usdc.svg"
+                },
+                "NLS": {
+                    "ibc": {
+                        "network": "NOLUS",
+                        "currency": "NLS"
+                    },
+                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-nls.svg"
+                }
+            }
+        },
         "STARGAZE": {
             "currencies": {
                 "STARS": {
@@ -620,7 +871,8 @@
         },
         "NOLUS": {
             "NEUTRON": "channel-3839",
-            "OSMOSIS": "channel-0"
+            "OSMOSIS": "channel-0",
+            "SOLANA": "channel-XX"
         },
         "OSMOSIS": {
             "AKASH": "channel-1",
@@ -643,6 +895,9 @@
             "STARGAZE": "channel-75",
             "STRIDE": "channel-326",
             "XION": "channel-89321"
+        },
+        "SOLANA": {
+            "NOLUS": "channel-XX"
         }
     }
 }

--- a/mainnet/pirin-1/topology.json
+++ b/mainnet/pirin-1/topology.json
@@ -571,9 +571,9 @@
                     },
                     "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-cbbtc.svg"
                 },
-                "W_ETH": {
+                "WETH": {
                     "native": {
-                        "name": "W_ETH",
+                        "name": "WETH",
                         "symbol": "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
                         "decimal_digits": 8
                     },

--- a/mainnet/pirin-1/topology.json
+++ b/mainnet/pirin-1/topology.json
@@ -672,7 +672,7 @@
         "NOLUS": {
             "NEUTRON": "channel-3839",
             "OSMOSIS": "channel-0",
-            "SOLANA": "channel-XX"
+            "SOLANA": "channel-61957"
         },
         "OSMOSIS": {
             "AKASH": "channel-1",
@@ -697,7 +697,7 @@
             "XION": "channel-89321"
         },
         "SOLANA": {
-            "NOLUS": "channel-XX"
+            "NOLUS": "channel-0"
         }
     }
 }

--- a/mainnet/pirin-1/topology.json
+++ b/mainnet/pirin-1/topology.json
@@ -563,62 +563,6 @@
                     },
                     "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-sol.svg"
                 },
-                "JUP": {
-                    "native": {
-                        "name": "JUP",
-                        "symbol": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jup.svg"
-                },
-                "JLP": {
-                    "native": {
-                        "name": "JLP",
-                        "symbol": "27G8MtK7VtTcCHkpASjSDdkWWYfoqT6ggEuKidVJidD4",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jlp.svg"
-                },
-                "MET": {
-                    "native": {
-                        "name": "MET",
-                        "symbol": "METvsvVRapdj9cFLzq4Tr43xK4tAjQfwX76z3n6mWQL",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-met.svg"
-                },
-                "PENGU": {
-                    "native": {
-                        "name": "PENGU",
-                        "symbol": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-pengu.svg"
-                },
-                "TRUMP": {
-                    "native": {
-                        "name": "TRUMP",
-                        "symbol": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-trump.svg"
-                },
-                "PUMP": {
-                    "native": {
-                        "name": "PUMP",
-                        "symbol": "pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-pump.svg"
-                },
-                "JTO": {
-                    "native": {
-                        "name": "JTO",
-                        "symbol": "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
-                        "decimal_digits": 9
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jto.svg"
-                },
                 "CB_BTC": {
                     "native": {
                         "name": "CB_BTC",
@@ -626,14 +570,6 @@
                         "decimal_digits": 8
                     },
                     "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-cbbtc.svg"
-                },
-                "JITO_SOL": {
-                    "native": {
-                        "name": "JITO_SOL",
-                        "symbol": "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
-                        "decimal_digits": 9
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-jitosol.svg"
                 },
                 "W_ETH": {
                     "native": {
@@ -643,14 +579,6 @@
                     },
                     "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-weth.svg"
                 },
-                "XAUT0": {
-                    "native": {
-                        "name": "XAUT0",
-                        "symbol": "AymATz4TCL9sWNEEV9Kvyz45CHVhDZ6kUgjTJPzLpU9P",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-xaut0.svg"
-                },
                 "HYPE": {
                     "native": {
                         "name": "HYPE",
@@ -658,134 +586,6 @@
                         "decimal_digits": 9
                     },
                     "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-hype.svg"
-                },
-                "ZEC": {
-                    "native": {
-                        "name": "ZEC",
-                        "symbol": "A7bdiYdS5GjqGFtxf17ppRHtDKPkkRqbKtR27dxvQXaS",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-zec.svg"
-                },
-                "RAY": {
-                    "native": {
-                        "name": "RAY",
-                        "symbol": "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-ray.svg"
-                },
-                "ORCA": {
-                    "native": {
-                        "name": "ORCA",
-                        "symbol": "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-orca.svg"
-                },
-                "BP": {
-                    "native": {
-                        "name": "BP",
-                        "symbol": "BPxxfRCXkUVhig4HS1Lh7kZqV6SPJhzfEk4x6fVBjPCy",
-                        "decimal_digits": 9
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-bp.svg"
-                },
-                "MU": {
-                    "native": {
-                        "name": "MU",
-                        "symbol": "MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-mu.svg"
-                },
-                "SPCX": {
-                    "native": {
-                        "name": "SPCX",
-                        "symbol": "SPCXxcqXj6e5dJDVNovHN8744zkbhM2bYudU45BimGb",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-spcx.svg"
-                },
-                "SKHY": {
-                    "native": {
-                        "name": "SKHY",
-                        "symbol": "SKHYhSjuRWHgikq8eRKbtBbpABgJSkd7ytQV14i9EQ3",
-                        "decimal_digits": 6
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-skhy.svg"
-                },
-                "SPYX": {
-                    "native": {
-                        "name": "SPYX",
-                        "symbol": "XsoCS1TfEyfFhfvj8EtZ528L3CaKBDBRqRapnBbDF2W",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-spyx.svg"
-                },
-                "QQQX": {
-                    "native": {
-                        "name": "QQQX",
-                        "symbol": "Xs8S1uUs1zvS2p7iwtsG3b6fkhpvmwz4GYU3gWAmWHZ",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-qqqx.svg"
-                },
-                "NVDAX": {
-                    "native": {
-                        "name": "NVDAX",
-                        "symbol": "Xsc9qvGR1efVDFGLrVsmkzv3qi45LTBjeUKSPmx9qEh",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-nvdax.svg"
-                },
-                "CRCLX": {
-                    "native": {
-                        "name": "CRCLX",
-                        "symbol": "XsueG8BtpquVJX9LVLLEGuViXUungE6WmK5YZ3p3bd1",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-crclx.svg"
-                },
-                "TSLAX": {
-                    "native": {
-                        "name": "TSLAX",
-                        "symbol": "XsDoVfqeBukxuZHWhdvWHBhgEHjGNst4MLodqsJHzoB",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-tslax.svg"
-                },
-                "COINX": {
-                    "native": {
-                        "name": "COINX",
-                        "symbol": "Xs7ZdzSHLU9ftNJsii5fCeJhoRWSC32SQGzGQtePxNu",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-coinx.svg"
-                },
-                "MSTRX": {
-                    "native": {
-                        "name": "MSTRX",
-                        "symbol": "XsP7xzNPvEHS1m6qfanPUGjNmdnmsLKEoNAnHjdxxyZ",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-mstrx.svg"
-                },
-                "GOOGLX": {
-                    "native": {
-                        "name": "GOOGLX",
-                        "symbol": "XsCPL9dNWBMvFtTmwcCA5v3xWPSMEBCszbQdiLLq6aN",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-googlx.svg"
-                },
-                "AAPLX": {
-                    "native": {
-                        "name": "AAPLX",
-                        "symbol": "XsbEhLAtcf6HdfpFZ5xEMdqW8nfAvcsP5bdudRLJzJp",
-                        "decimal_digits": 8
-                    },
-                    "icon": "https://raw.githubusercontent.com/nolus-protocol/webapp/main/src/config/currencies/icons/solana-aaplx.svg"
                 },
                 "USDC": {
                     "native": {


### PR DESCRIPTION
## Summary
Adds the `SOLANA` network to `mainnet/pirin-1/topology.json` and `mainnet/pirin-1/currencies.json`, mirroring the Solana integration already present on `testnet/rila-3` but populated with the full long-basket token set (30 SPL tokens incl. USDC) from the `solana-long-basket-tokens` list.

## Changes
- **topology.json**: `SOLANA` network entry with native currency definitions (SPL mint address as `symbol`) for all 30 tokens, plus `NLS` as an `ibc` back-reference to `NOLUS`; `NOLUS <-> SOLANA` channel entries added under `channels`.
- **currencies.json**: `SOLANA` entry under `networks.list` with descriptive names/tickers/decimals for all 30 tokens, `amm_pools: []` (Solana routing goes through an aggregator, not fixed AMM pools), the `NOLUS <-> SOLANA` channel pairing appended to `networks.channels`, and a new `SOLANA-METIS-USDC` protocol: `USDC` as `Lpn`, the remaining 29 tokens as `Lease`, `NLS` as `Native`.

## Known placeholders
IBC channels between `NOLUS` and `SOLANA` are **not opened yet**. Both directions currently use `channel-XX` placeholders — these need to be replaced with the real channel IDs once the channel is established.

## Verification
- Both files validated as well-formed JSON.
- Cross-checked: every ticker referenced in the `SOLANA-METIS-USDC` protocol (`Lpn` + `Lease`) exists in `networks.list.SOLANA.currencies`, and the currency set is identical between `topology.json` and `currencies.json` (30 entries each, including `NLS`).