### PR TITLE
feat: add solana-metis-usdc protocol definition

### DIFF
--- a/mainnet/pirin-1/protocols/solana-metis-usdc.json
+++ b/mainnet/pirin-1/protocols/solana-metis-usdc.json
@@ -1,0 +1,22 @@
+{
+    "dex": "metis",
+    "dex_network": "SOLANA",
+    "lpn_ticker": "USDC",
+    "stable_currency_ticker": "USDC",
+    "lease_currencies_tickers": [
+        "CB_BTC",
+        "HYPE",
+        "SOL",
+        "WETH"
+    ],
+    "payment_only_currencies_tickers": [],
+    "swap_pairs": {
+        "USDC": [
+            "CB_BTC",
+            "HYPE",
+            "SOL",
+            "WETH",
+            "NLS"
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #157 (merged). Adds `mainnet/pirin-1/protocols/solana-metis-usdc.json`, which was supposed to be part of that PR but landed as a commit pushed just after #157 was merged, so it never made it into `main`.

## Contents
Follows the shape of the existing per-protocol files (e.g. `osmosis-osmosis-usdc_axelar.json`) and mirrors the `SOLANA-METIS-USDC` entry already merged into `currencies.json`:
- `lpn_ticker` / `stable_currency_ticker`: `USDC`
- `lease_currencies_tickers`: `CB_BTC`, `HYPE`, `SOL`, `WETH`
- `swap_pairs`: everything (including `NLS`, the native currency) routes directly to `USDC`, since Metis/Jupiter is an aggregator with no fixed AMM pools on this dex

## Verification
- Valid JSON.
- Cross-checked against `main`'s current `currencies.json`: `lease_currencies_tickers` matches the `SOLANA-METIS-USDC.Lease` set exactly, `lpn_ticker` matches `Lpn.dex_currency`, and every ticker referenced (including `NLS`) resolves against `networks.list.SOLANA.currencies`.