### PR TITLE
fix: set solray_program_id on SOLANA network for pirin-1 and rila-3

### DIFF
--- a/mainnet/pirin-1/topology.json
+++ b/mainnet/pirin-1/topology.json
@@ -554,6 +554,7 @@
             }
         },
         "SOLANA": {
+            "solray_program_id": "9ATDq9dpDcM517hncjHnbWsBXzsNxKvqdfJ4L5qHJYy2",
             "currencies": {
                 "SOL": {
                     "native": {

--- a/testnet/rila-3/topology.json
+++ b/testnet/rila-3/topology.json
@@ -199,6 +199,7 @@
             }
         },
         "SOLANA": {
+            "solray_program_id": "FqTKBXhdsKZvYb3SjCs3hsh6XTo7XSroyfjzqMbnGNve",
             "currencies": {
                 "SOL": {
                     "native": {


### PR DESCRIPTION
## Why

The SOLANA network in both topology files had no `solray_program_id`. The topology tool in nolus-money-market treats such a network as Cosmos-kind and derives an `ibc/<sha256>` voucher as the NLS DEX symbol, which names nothing on Solana. That is why SOLANA-METIS-USDC has no NLS price: the registry never carried the SPL mint.

NLS stays modelled as an `ibc` currency pointing at NOLUS. Only the network-level program id is added, so the tool derives the Solray mirror mint for `transfer/channel-0/unls`.

## Verification

Ran the nolus-money-market currencies generator against each topology paired with its `solana-metis-usdc.json`:

| Network | Bank symbol | DEX symbol |
|---|---|---|
| pirin-1 | `unls` | `B9Vhg6XrNswZvLdKgpKhZ9Fj9yV7j2RxQKUaq5fmuphv` |
| rila-3 | `unls` | `6ZtSDkvNPN4c7jUtQPvFfoqemxLmvX6rXUKmqTxfHzDi` |

The pirin-1 mint matches the on-chain token created by program `9ATDq9dpDcM517hncjHnbWsBXzsNxKvqdfJ4L5qHJYy2`, and that program's vault-authority PDA is the mint's mint authority. The rila-3 mint exists on chain with zero supply under program `FqTKBXhdsKZvYb3SjCs3hsh6XTo7XSroyfjzqMbnGNve`. The currencies crate tests pass.

## Follow-up

SOLANA-METIS-USDC on pirin-1 needs a rebuild and migration to pick up the new registry. SOLANA-METIS-SOL needs no redeploy; it inherits the corrected NLS symbol on its next rebuild.