### PR TITLE
feat(ci): allow overriding the protocol identity stamped into a build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,16 @@ on:
         description: "Smart contracts release"
         type: "string"
         required: true
+      protocol-identity-network:
+        description: "Network stamped into the protocol package identity; defaults to the network input. Set only to match an already deployed protocol whose identity differs."
+        type: "string"
+        required: false
+        default: ""
+      protocol-identity-name:
+        description: "Name stamped into the protocol package identity; defaults to the protocol input. Set only to match an already deployed protocol whose identity differs."
+        type: "string"
+        required: false
+        default: ""
 
 env:
   profile: |-
@@ -124,9 +134,9 @@ jobs:
             "./build-configuration/topology.json"
       - env:
           network: |-
-            ${{ inputs.network }}
+            ${{ inputs.protocol-identity-network || inputs.network }}
           protocol: |-
-            ${{ inputs.protocol }}
+            ${{ inputs.protocol-identity-name || inputs.protocol }}
         run: |-
           set -eu
 


### PR DESCRIPTION
## Why

The builder stamps the protocol package identity from the workflow's `network` and `protocol` inputs. The rila-3 SOLANA-METIS-USDC deployment was hand-built with identity `METIS / SOLANA`, so a build from this workflow (`solana-metis-usdc / rila-3`) is rejected at migration:

```
[Versioning] The package names do not match! The current package is "name: METIS, network: SOLANA", the new package is "name: solana-metis-usdc, network: rila-3".
```

## What

Two optional `workflow_dispatch` inputs, `protocol-identity-network` and `protocol-identity-name`. Empty (the default) keeps today's behaviour. Set them only to match an already deployed protocol whose identity differs.

pirin-1 SOLANA-METIS-USDC and rila-3 SOLANA-METIS-SOL already carry the workflow's convention and need no override.